### PR TITLE
Fix upgrades.js by checking if params are null

### DIFF
--- a/upgrades.js
+++ b/upgrades.js
@@ -23,7 +23,7 @@ H5PUpgrades['H5P.Portfolio'] = (function () {
               return replaceSubContentIDs(param);
             });
           }
-          else if (typeof params === 'object') {
+          else if (typeof params === 'object' && params !== null) {
             if (params.library && params.subContentId) {
               /*
                 * NOTE: We avoid using H5P.createUUID since this is an upgrade


### PR DESCRIPTION
`typeof null` equals to 'object'.(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null) That could lead to the error `Cannot read properties of null (reading library)` If we check if params is null we can avoid this error.